### PR TITLE
Fix link text for pro version

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
 
     <div class="section cta-buttons">
       <a href="#">🔻 Download Lite Version</a>
-      <a href="https://talenmagistro.gumroad.com/l/luhnj">💚 Get Pro on Patreon</a>
+      <a href="https://talenmagistro.gumroad.com/l/luhnj">💚 Get Pro on Gumroad</a>
     </div>
 
     <div class="section">


### PR DESCRIPTION
## Summary
- fix the pro version call to action text to match the Gumroad link

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6866ddaa91608323b0594613505c25f0